### PR TITLE
SCRUM-15 BE: API reset password (tentative)

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,11 +1,16 @@
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
+const crypto = require("crypto")
 const { User } = require("../models");
 const registerSchema = require("../validators/registerValidator");
 const loginSchema = require("../validators/loginValidator");
+const resetPasswordRequestSchema = require("../validators/resetPasswordRequestValidator");
+const resetPasswordSchema = require("../validators/resetPasswordValidator");
 const { BadRequestError, UnauthenticatedError } = require("../errors");
 
 const JWT_SECRET = process.env.JWT_SECRET || "supersecretkey";
+
+const passwordResetTokens = new Map();
 
 const authController = {
   async register(req, res, next) {
@@ -81,6 +86,84 @@ const authController = {
       next(err);
     }
   },
+
+  async requestPasswordReset(req, res, next) {
+    const { error, value } = resetPasswordRequestSchema.validate(req.body);
+    if (error) {
+      return res.status(400).json({ message: error.details[0].message });
+    }
+
+    const { email } = value;
+
+    try {
+      const user = await User.findByPk(email.toLowerCase());
+      if (!user) {        
+        return res.status(200).json({
+          message: "If your email exists in our system, you will receive reset instructions."
+        });
+      }
+     
+      const resetToken = crypto.randomBytes(32).toString('hex');      
+     
+      passwordResetTokens.set(email.toLowerCase(), {
+        token: resetToken,
+        expires: Date.now() + 3600000 // 1 hour in milliseconds
+      });
+
+      // In a production  we will send this token via email?     
+      return res.status(200).json({
+        message: "If your email exists in our system, you will receive reset instructions.",
+        // ONLY FOR TESTING 
+        token: resetToken
+      });
+    } catch (err) {
+      console.error("Password reset request error:", err);
+      next(err);
+    }
+  },
+
+  async resetPassword(req, res, next) {
+    const { error, value } = resetPasswordSchema.validate(req.body);
+    if (error) {
+      return res.status(400).json({ message: error.details[0].message });
+    }
+
+    const { email, token, newPassword } = value;
+    const lowerEmail = email.toLowerCase();
+
+    try {      
+      const resetData = passwordResetTokens.get(lowerEmail);
+      
+      if (!resetData || resetData.token !== token) {
+        return res.status(400).json({ message: "Invalid or expired token" });
+      }
+
+      if (resetData.expires < Date.now()) {
+        passwordResetTokens.delete(lowerEmail);
+        return res.status(400).json({ message: "Token has expired" });
+      }
+
+      const user = await User.findByPk(lowerEmail);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      if (await bcrypt.compare(newPassword, user.password)) {
+        return res.status(400).json({ message: "New password must be different from the old one" });
+      }
+
+      const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+      await user.update({ password: hashedPassword });
+ 
+      passwordResetTokens.delete(lowerEmail);
+
+      return res.status(200).json({ message: "Password reset successful" });
+    } catch (err) {
+      console.error("Password reset error:", err);
+      next(err);
+    }
+  }
 };
 
 module.exports = authController;

--- a/src/routes/authRouter.js
+++ b/src/routes/authRouter.js
@@ -9,4 +9,7 @@ router.post("/logout", authMiddleware, (req, res) => {
   res.status(200).json({ message: `User ${req.user.email} logged out.` });
 });
 
+router.post("/request-password-reset", authController.requestPasswordReset);
+router.post("/reset-password", authController.resetPassword);
+
 module.exports = router;

--- a/src/validators/resetPasswordRequestValidator.js
+++ b/src/validators/resetPasswordRequestValidator.js
@@ -1,0 +1,14 @@
+const Joi = require("joi");
+
+const resetPasswordRequestSchema = Joi.object({
+  email: Joi.string()
+    .email({ tlds: { allow: false } })
+    .lowercase()
+    .required()
+    .messages({
+      "string.email": "Please provide a valid email address",
+      "any.required": "Email is required"
+    })
+});
+
+module.exports = resetPasswordRequestSchema;

--- a/src/validators/resetPasswordValidator.js
+++ b/src/validators/resetPasswordValidator.js
@@ -1,0 +1,26 @@
+const Joi = require("joi");
+
+const resetPasswordSchema = Joi.object({
+  email: Joi.string()
+    .email({ tlds: { allow: false } })
+    .lowercase()
+    .required()
+    .messages({
+      "string.email": "Please provide a valid email address",
+      "any.required": "Email is required"
+    }),
+  token: Joi.string()
+    .required()
+    .messages({
+      "any.required": "Reset token is required"
+    }),
+  newPassword: Joi.string()
+    .min(6)
+    .required()
+    .messages({
+      "string.min": "Password must be at least 6 characters long",
+      "any.required": "New password is required"
+    })
+});
+
+module.exports = resetPasswordSchema;


### PR DESCRIPTION
This implementation covers password reset in two steps:
1. `request-password-reset` generates a one-time token (stored in memory for now).
2. `reset-password` validates the token, updates the password, and includes Joi validation.

Possible improvements for later:
- Store tokens in DB with expiration timestamps instead of memory.
- Add email integration to send reset links.

Happy to work on any of these in future tickets!